### PR TITLE
Allow GHC 8.0.1, fixes #1

### DIFF
--- a/Text/XML/Pugi/Foreign/Node.hs
+++ b/Text/XML/Pugi/Foreign/Node.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}

--- a/pugixml.cabal
+++ b/pugixml.cabal
@@ -44,7 +44,7 @@ test-suite test
   build-depends:       base
                      , bytestring         >=0.10 && <0.11
                      , pugixml
-                     , tasty              >=0.10 && <0.11
+                     , tasty              >=0.10 && <0.12
                      , tasty-hunit        >=0.9  && <0.10
   type:                exitcode-stdio-1.0
   ghc-options:         -Wall -O2 -threaded

--- a/pugixml.cabal
+++ b/pugixml.cabal
@@ -28,10 +28,10 @@ library
                        Text.XML.Pugi.Foreign.Attr
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base               >=4.6  && <4.9
+  build-depends:       base               >=4.6  && <4.10
                      , bytestring         >=0.10 && <0.11
                      , data-default-class >=0.0  && <0.1
-                     , template-haskell   >=2.8  && <2.11
+                     , template-haskell   >=2.8  && <2.12
   -- hs-source-dirs:      
   c-sources:           pugixml-1.4/pugixml.cpp cbit/wrapper.cc
   include-dirs:        pugixml-1.4


### PR DESCRIPTION
A few bound upgrades, which required no changes.

There is also an issue with ImpredicativeTypes in GHC 8.0.1, which means the code won't compile. Fortunately just turning off that extension leaves everything working.